### PR TITLE
Fetch arXiv Tex Files given DOI

### DIFF
--- a/data_pipeline/ingestion/doi_ingestor.py
+++ b/data_pipeline/ingestion/doi_ingestor.py
@@ -2,6 +2,52 @@
 import os
 import tempfile
 from paperscraper.pdf import save_pdf
+import urllib.request
+import tarfile
+import glob
+
+def fetch_tex_by_doi(doi):
+    # Create a temporary directory to store the downloaded TEX
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zip_path = os.path.join(tmpdir, "article.tar.gz")
+        try:
+            # Attempt to save Zip File
+            local_filename, _ = urllib.request.urlretrieve(f'https://arxiv.org/src/{doi}', filename=zip_path)
+
+            # Extract Zip File
+            tar = tarfile.open(local_filename, "r:gz")
+            tar.extractall(tmpdir)
+            tar.close()
+
+            # Read main Tex file
+            tex_files = glob.glob(os.path.join(tmpdir, "*.tex"))
+            if not tex_files:
+                raise FileNotFoundError("Error: No .tex files found in directory")
+            if len(tex_files) > 1:
+                print(f"Warning: Multiple .tex files found in directory. Reading the first one: {tex_files[0]}")
+
+            with open(tex_files[0], "r", encoding="utf-8") as f:
+                tex_content = f.read()
+                return {
+                    'type': 'tex',
+                    'content': tex_content,
+                    'metadata': {
+                        'doi': doi,
+                        'source': 'doi_lookup'
+                    }
+                }
+
+        except Exception as e:
+            # If an error occurs (e.g. unsupported DOI, rate limiting, paywall)
+            # return a fallback HTML
+            return {
+                'type': 'html',
+                'content': f"<html><body>Failed to retrieve Tex for {doi}. Error: {str(e)}</body></html>",
+                'metadata': {
+                    'doi': doi,
+                    'source': 'doi_lookup'
+                }
+            }
 
 def fetch_article_by_doi(doi):
     # Try to retrieve PDF directly using paperscraper


### PR DESCRIPTION
## Summary
Add helper function to fetch LaTex files from arXiv given a DOI. Data is returned in the same format as the PDF function.
```
{
    'type': 'tex',
    'content': tex_content,
    'metadata': {
        'doi': doi,
        'source': 'doi_lookup'
    }
}
```

### Limitations:
- Only returns one of the Tex files if multiple are present
- Images/figures not handled

## Testing
Tested locally with DOI 2205.00247 which has a zipped file with:
- WKB0429t7.tex
- WKB0429t7.bbl
- p.pdf
- hepref.bib

Output:
```
{'type': 'tex', 'content': [correct content from WKB0429t7.tex but omitted to reduce size of description], 'metadata': {'doi': '2205.00247', 'source': 'doi_lookup'}}
```